### PR TITLE
Fix path to types file

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "dist/index.js",
   "module": "dist/es/index.js",
-  "types": "index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "lint": "eslint .",
     "check-format": "prettier --check .",


### PR DESCRIPTION
After build, the types file is generated within the `dist` directory.

Currently it is unable to find the types when importing:

<img width="968" alt="Screen Shot 2564-02-26 at 16 55 46" src="https://user-images.githubusercontent.com/35846795/109286420-c903fd80-7854-11eb-8553-7ee323c98836.png">
