### PR TITLE
Fix bug with outdated callback functions

### DIFF
--- a/src/SpreadsheetStateProvider.tsx
+++ b/src/SpreadsheetStateProvider.tsx
@@ -82,16 +82,12 @@ export default class SpreadsheetStateProvider<
   }
 
   componentDidMount(): void {
-    const {
-      onChange,
-      onModeChange,
-      onSelect,
-      onActivate,
-      onCellCommit,
-    } = this.props;
     this.unsubscribe = this.store.subscribe(
       (state: Types.StoreState<CellType>) => {
-        const { prevState } = this;
+        const {
+          props: { onChange, onModeChange, onSelect, onActivate, onCellCommit },
+          prevState,
+        } = this;
 
         if (state.lastCommit && state.lastCommit !== prevState.lastCommit) {
           for (const change of state.lastCommit) {


### PR DESCRIPTION
The component stores the callback function as they are on component mount, but this is not compatible with functional component callbacks, since the stored callback contains stale references to component state. To solve this, I just delay fetching the callback functions to when a store event occurs, so the latest callback function is always used.