### PR TITLE
Allow to paste empty string

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -139,7 +139,7 @@ export async function paste<Cell extends Types.CellBase>(
   text: string
 ): Promise<Partial<Types.StoreState<Cell>> | null> {
   const { active } = state;
-  if (!text || !active) {
+  if (!active) {
     return null;
   }
   const copiedMatrix = Matrix.split(text, (value) => ({ value }));


### PR DESCRIPTION
# Problem
I can not paste empty string (to override existing cell value).

# Cause
When pasting empty string `""`, `!text` returns true.

# Solution
I think `!text` filter is no longer necessary, isn't it?

Thanks!