### PR TITLE
Delete trailing new line character from pasted text

### DIFF
--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -154,11 +154,12 @@ export function split<T>(
   csv: string,
   transform: (value: string) => T,
   horizontalSeparator = "\t",
-  verticalSeparator = /\r\n|\n|\r/
+  verticalSeparator: string | RegExp = /\r\n|\n|\r/
 ): Matrix<T> {
+  const verticalSeparatorRegExp = typeof (verticalSeparator) === 'string' ? new RegExp(verticalSeparator) : verticalSeparator
   return csv
-    .replace(new RegExp('(' + verticalSeparator.source + ')$'), '') // delete trailing new line character
-    .split(verticalSeparator)
+    .replace(new RegExp('(' + verticalSeparatorRegExp.source + ')$'), '') // delete trailing new line character
+    .split(verticalSeparatorRegExp)
     .map((row) => row.split(horizontalSeparator).map(transform));
 }
 

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -154,9 +154,10 @@ export function split<T>(
   csv: string,
   transform: (value: string) => T,
   horizontalSeparator = "\t",
-  verticalSeparator: string | RegExp = /\r\n|\n|\r/
+  verticalSeparator = /\r\n|\n|\r/
 ): Matrix<T> {
   return csv
+    .replace(new RegExp('(' + verticalSeparator.source + ')$'), '') // delete trailing new line character
     .split(verticalSeparator)
     .map((row) => row.split(horizontalSeparator).map(transform));
 }


### PR DESCRIPTION
# Problem
When copying single empty cell from Google Spreadsheet (or copy some values from Excel), pasting result includes extra empty row.

# Cause
Because copied value from Google Spreadsheet's empty cell is "\n".

# Solution
I think it's better to delete trailing new line character from pasted text.