### PR TITLE
Make it possible to differentiate column row / content row 

### DIFF
--- a/src/HeaderRow.test.tsx
+++ b/src/HeaderRow.test.tsx
@@ -4,21 +4,21 @@
 
 import React from "react";
 import { render } from "@testing-library/react";
-import Row from "./Row";
+import HeaderRow from "./HeaderRow";
 
-describe("<Row />", () => {
+describe("<HeaderRow />", () => {
   test("renders", () => {
-    render(<Row row={0} />);
+    render(<HeaderRow />);
     const row = document.querySelector("tr");
     expect(row).not.toBeNull();
   });
   test("renders with children", () => {
     render(
-      <Row row={1}>
-        <td></td>
-      </Row>
+      <HeaderRow>
+        <th></th>
+      </HeaderRow>
     );
-    const cell = document.querySelector("tr td");
+    const cell = document.querySelector("tr th");
     expect(cell).not.toBeNull();
   });
 });

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -1,0 +1,6 @@
+import * as React from "react";
+import * as Types from "./types";
+
+const HeaderRow: Types.HeaderRowComponent = (props) => <tr {...props} />;
+
+export default HeaderRow;

--- a/src/Spreadsheet.tsx
+++ b/src/Spreadsheet.tsx
@@ -10,6 +10,7 @@ import { Parser as FormulaParser } from "hot-formula-parser";
 
 import DefaultTable from "./Table";
 import DefaultRow from "./Row";
+import DefaultHeaderRow from "./HeaderRow";
 import DefaultCornerIndicator from "./CornerIndicator";
 import DefaultColumnIndicator from "./ColumnIndicator";
 import DefaultRowIndicator from "./RowIndicator";
@@ -78,6 +79,8 @@ export type Props<CellType extends Types.CellBase> = {
   Table?: Types.TableComponent;
   /** The Spreadsheet's row component. */
   Row?: Types.RowComponent;
+  /** The spreadsheet's header row component */
+  HeaderRow?: Types.HeaderRowComponent;
   /** The Spreadsheet's cell component. */
   Cell?: Types.CellComponent<CellType>;
   /** Component rendered for cells in view mode. */
@@ -124,6 +127,7 @@ const Spreadsheet = <CellType extends Types.CellBase>(
     onKeyDown,
     Table = DefaultTable,
     Row = DefaultRow,
+    HeaderRow = DefaultHeaderRow,
     CornerIndicator = DefaultCornerIndicator,
     DataEditor = DefaultDataEditor,
     DataViewer = DefaultDataViewer,
@@ -397,7 +401,7 @@ const Spreadsheet = <CellType extends Types.CellBase>(
   const tableNode = React.useMemo(
     () => (
       <Table columns={size.columns} hideColumnIndicators={hideColumnIndicators}>
-        <Row>
+        <HeaderRow>
           {!hideRowIndicators && !hideColumnIndicators && <CornerIndicator />}
           {!hideColumnIndicators &&
             range(size.columns).map((columnNumber) =>
@@ -415,9 +419,9 @@ const Spreadsheet = <CellType extends Types.CellBase>(
                 <ColumnIndicator key={columnNumber} column={columnNumber} />
               )
             )}
-        </Row>
+        </HeaderRow>
         {range(size.rows).map((rowNumber) => (
-          <Row key={rowNumber}>
+          <Row key={rowNumber} row={rowNumber}>
             {!hideRowIndicators &&
               (rowLabels ? (
                 <RowIndicator
@@ -448,6 +452,7 @@ const Spreadsheet = <CellType extends Types.CellBase>(
       size.columns,
       hideColumnIndicators,
       Row,
+      HeaderRow,
       hideRowIndicators,
       CornerIndicator,
       columnLabels,

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,10 +149,19 @@ export type TableProps = React.PropsWithChildren<{
 export type TableComponent = React.ComponentType<TableProps>;
 
 /** Type of the Spreadsheet Row component props */
-export type RowProps = React.PropsWithChildren<{}>;
+export type RowProps = React.PropsWithChildren<{
+  /** The row index of the table */
+  row: number;
+}>;
 
 /** Type of the Row component */
 export type RowComponent = React.ComponentType<RowProps>;
+
+/** Type of the Spreadsheet HeaderRow component props */
+export type HeaderRowProps = React.PropsWithChildren<{}>;
+
+/** Type of the HeaderRow component */
+export type HeaderRowComponent = React.ComponentType<HeaderRowProps>;
 
 /** Type of the Spreadsheet RowIndicator component props */
 export type RowIndicatorProps = {


### PR DESCRIPTION
I added some new properties to the `Row` when rendering. Another way to implement this feature is to create a separated component `HeaderRow` in order to fully differentiate table body row and table header row.
