### PR TITLE
update: maintain cell info when deleting value

### DIFF
--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -259,7 +259,7 @@ function clear(state: Types.StoreState): Types.StoreState | void {
   return {
     ...state,
     data: selectedPoints.reduce(
-      (acc, point) => Matrix.set(point, undefined, acc),
+      (acc, point) => Matrix.set(point, { ...cell, value: undefined }, acc),
       state.data
     ),
     ...commit(changes),


### PR DESCRIPTION
Currently, if you enter 'delete' key on a cell, the cell itself in 'state.data' will be overridden with undefined which also delete the whole cell information including not only 'value' but DataEditor, DataViewer, and className. 
In order to prevent this, I just updated the clear action as it can override only a value property with undefined.