### PR TITLE
Fix Matrix.toArray

### DIFF
--- a/src/matrix.test.ts
+++ b/src/matrix.test.ts
@@ -177,8 +177,31 @@ describe("Matrix.toArray()", () => {
     ...EXAMPLE_MATRIX[1],
     ...EXAMPLE_MATRIX[2],
   ];
-  test("Flattens matrix values to an array", () => {
+  test("Flattens square matrix values to an array", () => {
     expect(Matrix.toArray(EXAMPLE_MATRIX)).toEqual(flattedMatrix);
+  });
+  test("Flattens horizontal matrix values to an array", () => {
+    expect(
+      Matrix.toArray([
+        [1, 2, 3],
+        [4, 5, 6],
+      ])
+    ).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+  test("Flattens vertical matrix values to an array", () => {
+    expect(
+      Matrix.toArray([
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ])
+    ).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+  test("Flattens column matrix values to an array", () => {
+    expect(Matrix.toArray([[1], [2], [3]])).toEqual([1, 2, 3]);
+  });
+  test("Flattens row matrix values to an array", () => {
+    expect(Matrix.toArray([[1, 2, 3]])).toEqual([1, 2, 3]);
   });
   test("Transforms matrix values and collects them to an array", () => {
     const transform = (value: number | undefined) => value && value * 2;

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -236,7 +236,7 @@ export function toArray<T1, T2>(
 ) {
   const array = [];
   for (let row = 0; row < matrix.length; row++) {
-    for (let column = 0; column < matrix.length; column++) {
+    for (let column = 0; column < matrix[row].length; column++) {
       const value = matrix[row][column];
       array.push(transform ? transform(value, { row, column }) : value);
     }


### PR DESCRIPTION
#### Issue

The `Matrix.toArray` function does not properly flatten non-square matrices to an array. This results in incorrect range returned by the default `getCellRangeValue`, which in turn results in the formulas getting incorrect arguments.

---

This PR adds the tests for the non-square matrices flattening and fixes the issue of looping the matrix columns incorrect amount of times due to the number of rows not matching the number of columns in non-square matrices.