### PR TITLE
Fix Formula Updating

### DIFF
--- a/src/Spreadsheet.tsx
+++ b/src/Spreadsheet.tsx
@@ -25,7 +25,7 @@ import DefaultDataEditor from "./DataEditor";
 import ActiveCell from "./ActiveCell";
 import Selected from "./Selected";
 import Copied from "./Copied";
-import { getBindingsForCell as defaultGetBindingsForCell } from "./bindings";
+import * as FormulaBindings from "./formula-bindings";
 import * as Selection from "./selection";
 import {
   range,
@@ -139,7 +139,7 @@ const Spreadsheet = <CellType extends Types.CellBase>(
     HeaderRow = DefaultHeaderRow,
     DataEditor = DefaultDataEditor,
     DataViewer = DefaultDataViewer,
-    getBindingsForCell = defaultGetBindingsForCell,
+    getBindingsForCell = FormulaBindings.getBindingsForCell,
     onChange = () => {},
     onModeChange = () => {},
     onSelect = () => {},

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1,26 +1,79 @@
-import flatMap from "array.prototype.flatmap";
-import * as Types from "./types";
-import * as Matrix from "./matrix";
-import { isFormulaValue, getReferences } from "./formula";
+import { Point } from "./point";
+import * as PointMap from "./point-map";
+import * as PointSet from "./point-set";
 
-/**
- * For given cell and spreadsheet data returns the cells affecting the cell value
- * @param cell - cell to get bindings for
- * @param data - spreadsheet data the cell relates to
- * @returns an array of coordinates in the given spreadsheet data of the cells that affect the given cell
- */
-export const getBindingsForCell: Types.GetBindingsForCell = (cell, data) => {
-  if (!isFormulaValue(cell.value)) {
-    return [];
-  }
-  const formula = cell.value;
-  const references = getReferences(formula);
-  // Recursively get references to dependencies
-  return flatMap(references, (coords) => {
-    const dependency = Matrix.get(coords, data);
-    const dependencyBindings = dependency
-      ? getBindingsForCell(dependency, data)
-      : [];
-    return [coords, ...dependencyBindings];
-  });
+/** The bindings between the cells in the spreadsheet*/
+export type Bindings = {
+  cellToDependents: PointMap.PointMap<PointSet.PointSet>;
+  cellToDependencies: PointMap.PointMap<PointSet.PointSet>;
 };
+
+export function create(): Bindings {
+  return {
+    cellToDependents: PointMap.from([]),
+    cellToDependencies: PointMap.from([]),
+  };
+}
+
+/** Set the dependencies for a cell */
+export function setDependencies(
+  bindings: Bindings,
+  cellPoint: Point,
+  dependencies: PointSet.PointSet
+): Bindings {
+  const previousDependencies =
+    PointMap.get(cellPoint, bindings.cellToDependencies) || PointSet.from([]);
+  const addedDependencies = PointSet.difference(
+    dependencies,
+    previousDependencies
+  );
+  const removedDependencies = PointSet.difference(
+    previousDependencies,
+    dependencies
+  );
+  const updatedCellToDependencies = PointMap.set(
+    cellPoint,
+    dependencies,
+    bindings.cellToDependencies
+  );
+  const updatedCellToDependentsWithAdded = PointSet.reduce(
+    addedDependencies,
+    (cellToDependents, dependency) => {
+      const existingPoints =
+        PointMap.get(dependency, cellToDependents) || PointSet.from([]);
+      return PointMap.set(
+        dependency,
+        PointSet.add(existingPoints, cellPoint),
+        cellToDependents
+      );
+    },
+    bindings.cellToDependents
+  );
+  const updatedCellToDependentsWithAddedWithoutRemoved = PointSet.reduce(
+    removedDependencies,
+    (cellToDependents, dependency) => {
+      const existingPoints =
+        PointMap.get(dependency, cellToDependents) || PointSet.from([]);
+      return PointMap.set(
+        dependency,
+        PointSet.remove(existingPoints, cellPoint),
+        cellToDependents
+      );
+    },
+    updatedCellToDependentsWithAdded
+  );
+  return {
+    cellToDependencies: updatedCellToDependencies,
+    cellToDependents: updatedCellToDependentsWithAddedWithoutRemoved,
+  };
+}
+
+/** Get the cells depending on the given cell */
+export function getDependents(
+  bindings: Bindings,
+  cellPoint: Point
+): PointSet.PointSet {
+  return (
+    PointMap.get(cellPoint, bindings.cellToDependents) || PointSet.from([])
+  );
+}

--- a/src/formula-bindings.test.ts
+++ b/src/formula-bindings.test.ts
@@ -1,4 +1,4 @@
-import { getBindingsForCell } from "./bindings";
+import { getBindingsForCell } from "./formula-bindings";
 import { Matrix } from "./matrix";
 import * as Point from "./point";
 import * as Types from "./types";

--- a/src/formula-bindings.ts
+++ b/src/formula-bindings.ts
@@ -1,0 +1,26 @@
+import flatMap from "array.prototype.flatmap";
+import * as Types from "./types";
+import * as Matrix from "./matrix";
+import { isFormulaValue, getReferences } from "./formula";
+
+/**
+ * For given cell and spreadsheet data returns the cells affecting the cell value
+ * @param cell - cell to get bindings for
+ * @param data - spreadsheet data the cell relates to
+ * @returns an array of coordinates in the given spreadsheet data of the cells that affect the given cell
+ */
+export const getBindingsForCell: Types.GetBindingsForCell = (cell, data) => {
+  if (!isFormulaValue(cell.value)) {
+    return [];
+  }
+  const formula = cell.value;
+  const references = getReferences(formula);
+  // Recursively get references to dependencies
+  return flatMap(references, (coords) => {
+    const dependency = Matrix.get(coords, data);
+    const dependencyBindings = dependency
+      ? getBindingsForCell(dependency, data)
+      : [];
+    return [coords, ...dependencyBindings];
+  });
+};

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,0 +1,86 @@
+/**
+ * The logic for updating the model of the spreadsheet
+ * @module
+ */
+
+// Requirements:
+// 1. when updating a cell that another cell is dependent on the dependent cell should be updated
+// 2. cells should only be calculated when their value or one of their dependencies change
+
+// Open Questions:
+// 1. Should bindings be computed flat or recursive?
+
+import * as Types from "./types";
+import * as Matrix from "./matrix";
+import { Point } from "./point";
+import * as Bindings from "./bindings";
+
+/** @todo move to types */
+type EvaluateCell = <CellType extends Types.CellBase>(
+  cell: CellType,
+  data: Matrix.Matrix<CellType>
+) => CellType;
+
+export type Model<CellType> = {
+  /** The raw cells data */
+  data: Matrix.Matrix<CellType>;
+  /** The evaluated cells data */
+  evaluatedData: Matrix.Matrix<CellType>;
+  /** The bindings between the cells */
+  bindings: Bindings.Bindings;
+};
+
+/** Create model from given data */
+export function create<CellType>(
+  data: Matrix.Matrix<CellType>
+): Model<CellType> {
+  return {
+    data,
+    /** @todo evaluate cells */
+    evaluatedData: data,
+    /** @todo calculate all bindings */
+    bindings: Bindings.create(),
+  };
+}
+
+/**
+ * Update given cell in the given model
+ * @param model - the model to update the cell in
+ * @param getBindingsForCell - a function that returns the cells that the cell depend on
+ * @param evaluateCell - a function that evaluates the value of the cell (based on past calculations)
+ * @param point - the coordinates of the cell
+ * @param cell - the cell's updated data
+ * @returns updated data, updated evaluated data and updated bindings
+ */
+export function updateCellValue<CellType extends Types.CellBase>(
+  model: Model<CellType>,
+  getBindingsForCell: Types.GetBindingsForCell,
+  evaluateCell: EvaluateCell,
+  point: Point,
+  cell: CellType
+): Model<CellType> {
+  const evaluatedCell = evaluateCell(cell, data);
+  const updatedCellBindings = getBindingsForCell(cell, data);
+  const updatedData = Matrix.set(point, cell, data);
+  const updatedEvaluatedData = Matrix.set(point, evaluatedCell, evaluatedData);
+  const updatedBindings = Bindings.setDependencies(
+    bindings,
+    point,
+    updatedCellBindings
+  );
+  const dependents = Bindings.getDependents(bindings, point);
+  /** @todo update dependents */
+  return {
+    data: updatedData,
+    evaluatedData: updatedEvaluatedData,
+    bindings: updatedBindings,
+  };
+}
+
+function updateEvaluatedDataWithCellValue<CellType extends Types.CellBase>(
+  evaluatedData: Matrix.Matrix<CellType>,
+  data: Matrix.Matrix<CellType>,
+  getBindingsForCell: Types.GetBindingsForCell,
+  evaluateCell: (cell: CellType, data: Matrix.Matrix<CellType>) => CellType,
+  point: Point
+) {}

--- a/src/point-map.ts
+++ b/src/point-map.ts
@@ -158,3 +158,12 @@ export function filter<T>(
 export function isEmpty(map: PointMap<unknown>): boolean {
   return Object.keys(map).length === 0;
 }
+
+/** Get the point keys of the given map */
+// export function getKeys(map: PointMap<unknown>): Point.Point[] {
+//   return reduce(
+//     (acc, value, point) => [...acc, point],
+//     map,
+//     [] as Point.Point[]
+//   );
+// }

--- a/src/point-set.ts
+++ b/src/point-set.ts
@@ -34,6 +34,29 @@ export function min(set: PointSet): Point.Point {
   return { row, column: minKey(set[row]) };
 }
 
+/** Add given point to the given set */
+export const add = (set: PointSet, point: Point.Point): PointSet =>
+  PointMap.set<boolean>(point, true, set);
+
+export const remove = (set: PointSet, point: Point.Point): PointSet =>
+  PointMap.unset<boolean>(point, set);
+
+/** Applies a function against an accumulator and each point in the set (from left to right) to reduce it to a single value */
+export const reduce = <T>(
+  set: PointSet,
+  reducer: (acc: T, point: Point.Point) => T,
+  initialValue: T
+): T =>
+  PointMap.reduce(
+    (acc, value, point) => reducer(acc, point),
+    set,
+    initialValue
+  );
+
+/** Creates set from given set without the points in target */
+export const difference = (set: PointSet, target: PointSet): PointSet =>
+  reduce(target, (newSet, point) => remove(newSet, point), set);
+
 const maxKey = (object: Record<number, any>): number =>
   // @ts-ignore
   Math.max(...Object.keys(object));


### PR DESCRIPTION
Formula updating is currently broken in some edge cases as specified in #63.
This PR attempts to introduce a new model for formula updating that follows a new data model.

The data model:
```typescript
type Bindings = {
  cellToDependents: PointMap.PointMap<PointSet.PointSet>;
  cellToDependencies: PointMap.PointMap<PointSet.PointSet>;
};

type Model<CellType> = {
  /** The raw cells data */
  data: Matrix.Matrix<CellType>;
  /** The evaluated cells data */
  evaluatedData: Matrix.Matrix<CellType>;
  /** The bindings between the cells */
  bindings: Bindings;
};
```
The idea is to keep track of evaluated values and update them when necessary. This way needless computations are avoided and formula cells depending on others would be updated correctly.

### Todo
 - [ ] Complete basic implementation
 - [ ] Test model
 - [ ] Test newly introduced data strucutures methods
 - [ ] Error on cycling references