### PR TITLE
Allow data to be set in viewer

### DIFF
--- a/src/Cell.test.tsx
+++ b/src/Cell.test.tsx
@@ -16,6 +16,8 @@ const MOCK_FORMULA_PARSER = {} as FormulaParser;
 const MOCK_SELECT = jest.fn();
 const MOCK_ACTIVATE = jest.fn();
 const MOCK_SET_CELL_DIMENSIONS = jest.fn();
+const MOCK_SET_CELL_DATA = jest.fn();
+const MOCK_GET_BINDINGS_FOR_CELL = jest.fn();
 const EXAMPLE_ROW = 0;
 const EXAMPLE_COLUMN = 0;
 const EXAMPLE_PROPS: Types.CellComponentProps = {
@@ -32,12 +34,15 @@ const EXAMPLE_PROPS: Types.CellComponentProps = {
   select: MOCK_SELECT,
   activate: MOCK_ACTIVATE,
   setCellDimensions: MOCK_SET_CELL_DIMENSIONS,
+  setCellData: MOCK_SET_CELL_DATA,
+  getBindingsForCell: MOCK_GET_BINDINGS_FOR_CELL,
 };
 const EXAMPLE_DATA_VIEWER_PROPS: Types.DataViewerProps = {
   row: EXAMPLE_ROW,
   column: EXAMPLE_COLUMN,
   cell: EXAMPLE_PROPS.data,
   formulaParser: MOCK_FORMULA_PARSER,
+  setCellData: MOCK_SET_CELL_DATA,
 };
 const EXAMPLE_READ_ONLY_DATA: Types.CellBase = { value: null, readOnly: true };
 const EXAMPLE_DATA_WITH_CLASS_NAME: Types.CellBase = {
@@ -53,6 +58,7 @@ const EXAMPLE_CUSTOM_DATA_VIEWER_PROPS: Types.DataViewerProps = {
   column: EXAMPLE_COLUMN,
   cell: EXAMPLE_DATA_WITH_CUSTOM_DATA_VIEWER,
   formulaParser: MOCK_FORMULA_PARSER,
+  setCellData: MOCK_SET_CELL_DATA,
 };
 const EXAMPLE_POINT: Point.Point = { row: EXAMPLE_ROW, column: EXAMPLE_COLUMN };
 

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -24,6 +24,7 @@ export const Cell: React.FC<Types.CellComponentProps> = ({
   select,
   activate,
   setCellDimensions,
+  setCellData,
 }): React.ReactElement => {
   const rootRef = React.useRef<HTMLTableCellElement | null>(null);
   const point = React.useMemo(
@@ -89,6 +90,7 @@ export const Cell: React.FC<Types.CellComponentProps> = ({
         column={column}
         cell={data}
         formulaParser={formulaParser}
+        setCellData={setCellData}
       />
     </td>
   );
@@ -113,6 +115,13 @@ export const enhance = (
   return function CellWrapper(props) {
     const { row, column } = props;
     const dispatch = useDispatch();
+    const setCellData = React.useCallback(
+      (data: Types.CellBase) =>
+        dispatch(
+          Actions.setCellData({ column, row }, data, props.getBindingsForCell)
+        ),
+      [dispatch, props.getBindingsForCell, column, row]
+    );
     const select = React.useCallback(
       (point: Point.Point) => dispatch(Actions.select(point)),
       [dispatch]
@@ -167,6 +176,7 @@ export const enhance = (
         select={select}
         activate={activate}
         setCellDimensions={setCellDimensions}
+        setCellData={setCellData}
       />
     );
   };

--- a/src/DataViewer.test.tsx
+++ b/src/DataViewer.test.tsx
@@ -13,12 +13,14 @@ import DataViewer, {
 import * as Types from "./types";
 
 const MOCK_FORMULA_PARSER = {} as FormulaParser;
+const MOCK_SET_CELL_DATA = jest.fn();
 const EXAMPLE_VALUE = "EXAMPLE_VALUE";
 const EXAMPLE_PROPS: Types.DataViewerProps = {
   row: 0,
   column: 0,
   cell: { value: EXAMPLE_VALUE },
   formulaParser: MOCK_FORMULA_PARSER,
+  setCellData: MOCK_SET_CELL_DATA,
 };
 
 describe("<DataViewer />", () => {

--- a/src/Spreadsheet.tsx
+++ b/src/Spreadsheet.tsx
@@ -464,6 +464,8 @@ const Spreadsheet = <CellType extends Types.CellBase>(
                 // @ts-ignore
                 DataViewer={DataViewer}
                 formulaParser={formulaParser}
+                // @ts-ignore
+                getBindingsForCell={getBindingsForCell}
               />
             ))}
           </Row>
@@ -486,6 +488,7 @@ const Spreadsheet = <CellType extends Types.CellBase>(
       Cell,
       DataViewer,
       formulaParser,
+      getBindingsForCell,
     ]
   );
 

--- a/src/stories/CustomCell.tsx
+++ b/src/stories/CustomCell.tsx
@@ -21,6 +21,7 @@ const CustomCell: CellComponent = ({
   formulaParser,
   data,
   DataViewer,
+  setCellData,
 }) => {
   const rootRef = React.createRef<HTMLTableCellElement>();
 
@@ -86,6 +87,7 @@ const CustomCell: CellComponent = ({
         column={column}
         cell={data}
         formulaParser={formulaParser}
+        setCellData={setCellData}
       />
     </td>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import { PointMap } from "./point-map";
 import { PointSet } from "./point-set";
 import { Matrix } from "./matrix";
 import { Selection } from "./selection";
+import * as Types from "./types";
 
 /** The base type of cell data in Spreadsheet */
 export type CellBase<Value = any> = {
@@ -102,6 +103,13 @@ export type CellComponentProps<Cell extends CellBase = CellBase> = {
   activate: (point: Point) => void;
   /** Set the dimensions of the cell at the given point with the given dimensions */
   setCellDimensions: (point: Point, dimensions: Dimensions) => void;
+  /**
+   * Calculate which cells should be updated when given cell updates.
+   * Defaults to: internal implementation which infers dependencies according to formulas.
+   */
+  getBindingsForCell: Types.GetBindingsForCell<Cell>;
+  /** Set data of the cell */
+  setCellData: (cell: Cell) => void;
 };
 
 /** Type of the Spreadsheet Cell component */
@@ -118,6 +126,8 @@ export type DataViewerProps<Cell extends CellBase = CellBase> =
   DataComponentProps<Cell> & {
     /** Instance of `FormulaParser` */
     formulaParser: FormulaParser;
+    /** Set data of the cell */
+    setCellData: (cell: Cell) => void;
   };
 
 /** Type of the Spreadsheet DataViewer component */


### PR DESCRIPTION
This PR adds ability to set cell data from the viewer component. It allows users to create cells with controls, eg. checkboxes:

https://user-images.githubusercontent.com/6833443/169305427-da567895-7615-4aff-91df-1c984eadec71.mp4


https://user-images.githubusercontent.com/6833443/169305435-c69c3829-fc6f-447e-97e3-7978df2b3ab5.mp4


