### PR TITLE
Use lastChanged for onCellCommit coordinates

### DIFF
--- a/src/Spreadsheet.tsx
+++ b/src/Spreadsheet.tsx
@@ -209,7 +209,7 @@ const Spreadsheet = <CellType extends Types.CellBase>(
     const prevState = prevStateRef.current;
     if (state.lastCommit && state.lastCommit !== prevState.lastCommit) {
       for (const change of state.lastCommit) {
-        onCellCommit(change.prevCell, change.nextCell, state.active);
+        onCellCommit(change.prevCell, change.nextCell, state.lastChanged);
       }
     }
 


### PR DESCRIPTION
The `lastChanged` state property seems to contain the real coordinates to the cell which was last changed as opposed to the `active` property which may differ from the cell that was last changed if the user has selected a different cell. 

Resolves #83.