### PR TITLE
Handle formula parsing error and don't break entire React App

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -191,5 +191,9 @@ export function getFormulaComputedValue(
   formulaParser: FormulaParser
 ): Value {
   const formula = Formula.extractFormula(value);
-  return Formula.evaluate(formula, point, formulaParser);
+  try {
+    return Formula.evaluate(formula, point, formulaParser);
+  } catch (e) {
+    return '#REF!';
+  }
 }


### PR DESCRIPTION
Accidentally adding a bad formula like "= " would crash the entire app, which is undesirable.