### PR TITLE
Move types to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "scheduler": ">=0.19.0"
   },
   "dependencies": {
-    "@types/array.prototype.flatmap": "^1.2.2",
     "array.prototype.flatmap": "^1.2.5",
     "classnames": "^2.3.1",
     "fast-formula-parser": "^1.0.19",
@@ -54,6 +53,7 @@
     "@storybook/testing-library": "^0.2.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
+    "@types/array.prototype.flatmap": "^1.2.2",
     "@types/jest": "^29.5.0",
     "@types/node": "^16.7.10",
     "@types/react": "^16.14.0",


### PR DESCRIPTION
I think flatmap’s typings may be under `dependencies` by accident. This change does not affect the lockfile under Yarn classic.