### PR TITLE
QOL change: Export Model class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,4 @@ export type {
   HeaderRowProps,
   HeaderRowComponent,
 } from "./types";
-export {
-  createFormulaParser,
-  Model
-} from "./engine";
+export { createFormulaParser, Model } from "./engine";

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,4 +45,7 @@ export type {
   HeaderRowProps,
   HeaderRowComponent,
 } from "./types";
-export { createFormulaParser } from "./engine";
+export {
+  createFormulaParser,
+  Model
+} from "./engine";


### PR DESCRIPTION
We have a formula input in a separate component in which we want to use the data from the spreadsheet as our model.
The problem we have is that the data is, logically, not evaluated and it will still contain formulas, resulting to a formula string instead of an evaluated number.
If we want to evaluate the formula outside of the data, we need to use the Model class.
This class already has the dependency graph and the evaluation of the data, so that should be it

Local tests show that this change is enough to allow external formulas to be evaluated over the data, even nested formulas (e.g. External: '=A1+A2', A1: '=2+3', A2: '=2*A1' results in 15)
It would be great if the Model is exported from the root index.ts, hence this PR.