### PR TITLE
Enhance <Spreadsheet /> to Properly Handle Line Breaks Inside Quotes in CSV Pasting

### DIFF
--- a/src/DataViewer.tsx
+++ b/src/DataViewer.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
+import classNames from "classnames";
 import * as Types from "./types";
+import { hasLineBreaker } from "./util";
 
 export const TRUE_TEXT = "TRUE";
 export const FALSE_TEXT = "FALSE";
@@ -16,7 +18,13 @@ const DataViewer = <Cell extends Types.CellBase<Value>, Value>({
       {convertBooleanToText(value)}
     </span>
   ) : (
-    <span className="Spreadsheet__data-viewer">{value}</span>
+    <span
+      className={classNames("Spreadsheet__data-viewer", {
+        "Spreadsheet__data-viewer--preserve-breaks": hasLineBreaker(value),
+      })}
+    >
+      {value}
+    </span>
   );
 };
 

--- a/src/Spreadsheet.css
+++ b/src/Spreadsheet.css
@@ -86,6 +86,10 @@
   box-sizing: border-box;
 }
 
+.Spreadsheet__data-viewer--preserve-breaks {
+  white-space: pre-wrap;
+}
+
 .Spreadsheet__data-editor,
 .Spreadsheet__data-editor input {
   width: 100%;

--- a/src/matrix.test.ts
+++ b/src/matrix.test.ts
@@ -65,6 +65,19 @@ describe("Matrix.split()", () => {
     expect(Matrix.split(CSV, Number)).toEqual(EXAMPLE_MATRIX);
   });
 });
+describe("Matrix.splitWithLineBreaker()", () => {
+  it("Splits CSV string without line breaks correctly", () => {
+    const csv = "Value1\tValue2\tValue3";
+    const result = Matrix.splitWithLineBreaker(csv, (value) => value);
+    expect(result).toEqual([["Value1", "Value2", "Value3"]]);
+  });
+
+  it("Keeps line breaks inside double quotes", () => {
+    const csv = '"Value\n1"\tValue2\t"Value\n3"';
+    const result = Matrix.splitWithLineBreaker(csv, (value) => value);
+    expect(result).toEqual([["Value\n1", "Value2", "Value\n3"]]);
+  });
+});
 
 describe("Matrix.set()", () => {
   test("Sets value", () => {

--- a/src/matrix.test.ts
+++ b/src/matrix.test.ts
@@ -64,17 +64,10 @@ describe("Matrix.split()", () => {
   test("Constructs a matrix from a CSV string", () => {
     expect(Matrix.split(CSV, Number)).toEqual(EXAMPLE_MATRIX);
   });
-});
-describe("Matrix.splitWithLineBreaker()", () => {
-  it("Splits CSV string without line breaks correctly", () => {
-    const csv = "Value1\tValue2\tValue3";
-    const result = Matrix.splitWithLineBreaker(csv, (value) => value);
-    expect(result).toEqual([["Value1", "Value2", "Value3"]]);
-  });
 
-  it("Keeps line breaks inside double quotes", () => {
+  test("Keeps line breaks inside double quotes", () => {
     const csv = '"Value\n1"\tValue2\t"Value\n3"';
-    const result = Matrix.splitWithLineBreaker(csv, (value) => value);
+    const result = Matrix.split(csv, (value) => value);
     expect(result).toEqual([["Value\n1", "Value2", "Value\n3"]]);
   });
 });

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -172,6 +172,32 @@ export function split<T>(
     .map((row) => row.split(horizontalSeparator).map(transform));
 }
 
+/**
+ * Parses a CSV string that may contain line breaks within double quotes.
+ * This function splits the CSV content into rows and columns, considering line breaks
+ * inside double quotes as part of the data rather than a new row.
+ */
+export function splitWithLineBreaker<T>(
+  csv: string,
+  transform: (value: string) => T,
+  horizontalSeparator = "\t",
+  verticalSeparator: string | RegExp = /\r\n|\n|\r/
+): Matrix<T> {
+  // Temporarily replace line breaks inside quotes
+  const replaced = csv.replace(/"([^"]*?)"/g, (match, p1) => {
+    return p1.replace(/\n/g, "\\n");
+  });
+  return replaced.split(verticalSeparator).map((row) =>
+    row
+      .split(horizontalSeparator)
+      .map((line) => {
+        // Restore original line breaks in each line
+        return line.replace(/\\n/g, "\n");
+      })
+      .map(transform)
+  );
+}
+
 /** Returns whether the point exists in the matrix or not. */
 export function has(point: Point.Point, matrix: Matrix<unknown>): boolean {
   const firstRow = matrix[0];

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -167,22 +167,6 @@ export function split<T>(
   horizontalSeparator = "\t",
   verticalSeparator: string | RegExp = /\r\n|\n|\r/
 ): Matrix<T> {
-  return csv
-    .split(verticalSeparator)
-    .map((row) => row.split(horizontalSeparator).map(transform));
-}
-
-/**
- * Parses a CSV string that may contain line breaks within double quotes.
- * This function splits the CSV content into rows and columns, considering line breaks
- * inside double quotes as part of the data rather than a new row.
- */
-export function splitWithLineBreaker<T>(
-  csv: string,
-  transform: (value: string) => T,
-  horizontalSeparator = "\t",
-  verticalSeparator: string | RegExp = /\r\n|\n|\r/
-): Matrix<T> {
   // Temporarily replace line breaks inside quotes
   const replaced = csv.replace(/"([^"]*?)"/g, (match, p1) => {
     return p1.replace(/\n/g, "\\n");

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -10,7 +10,7 @@ import {
   EntireRowsSelection,
   EntireWorksheetSelection,
 } from "./selection";
-import { hasLineBreaker, isActive } from "./util";
+import { isActive } from "./util";
 import * as Actions from "./actions";
 import { Model, updateCellValue, createFormulaParser } from "./engine";
 
@@ -177,9 +177,8 @@ export default function reducer(
       if (!active) {
         return state;
       }
-      const copied = hasLineBreaker(text)
-        ? Matrix.splitWithLineBreaker(text, (value) => ({ value }))
-        : Matrix.split(text, (value) => ({ value }));
+
+      const copied = Matrix.split(text, (value) => ({ value }));
       const copiedSize = Matrix.getSize(copied);
 
       const selectedRange = state.selected.toRange(state.model.data);

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -10,7 +10,7 @@ import {
   EntireRowsSelection,
   EntireWorksheetSelection,
 } from "./selection";
-import { isActive } from "./util";
+import { hasLineBreaker, isActive } from "./util";
 import * as Actions from "./actions";
 import { Model, updateCellValue, createFormulaParser } from "./engine";
 
@@ -177,7 +177,9 @@ export default function reducer(
       if (!active) {
         return state;
       }
-      const copied = Matrix.split(text, (value) => ({ value }));
+      const copied = hasLineBreaker(text)
+        ? Matrix.splitWithLineBreaker(text, (value) => ({ value }))
+        : Matrix.split(text, (value) => ({ value }));
       const copiedSize = Matrix.getSize(copied);
 
       const selectedRange = state.selected.toRange(state.model.data);

--- a/src/util.ts
+++ b/src/util.ts
@@ -167,3 +167,7 @@ export function shouldHandleClipboardEvent(
 export function isFocusedWithin(element: Element): boolean {
   return element.matches(FOCUS_WITHIN_SELECTOR);
 }
+
+export function hasLineBreaker(value: unknown) {
+  return typeof value === "string" && value.includes("\n");
+}


### PR DESCRIPTION
# Added feature to recognize line breaks when pasting CSV content

> When copying content from a CSV for pasting, if there are line break indicators within the content, pasting it into `<Spreadsheet />` creates a new row due to these indicators. This PR is submitted to improve this behavior.

<img width="200" alt="image" src="https://github.com/iddan/react-spreadsheet/assets/44981120/f94dcfce-c3ee-4a77-8654-b39b4717e829">

When copying content like the one shown above from Google Sheets, it becomes a string like the following, with line break entities (`\n`) inside double quotes:

```
// Content copied from a Google Sheets cell
"this is first line.
this is second line."
```

Pasting such CSV content into `<Spreadsheet />` interprets double quotes as text and creates two rows due to the included line break indicators, even though the actual content has line breaks within the cell. The goal is to generate only one row (to-be).
|as-is|to-be|
|---|---|
|<img width="400" alt="image" src="https://github.com/iddan/react-spreadsheet/assets/44981120/23e3be27-9262-4fb2-997c-a71a770f279a">|<img width="400" alt="image" src="https://github.com/iddan/react-spreadsheet/assets/44981120/79b61524-22e7-4ad7-9e70-f9329754c63b">|

Previously, `Matrix.split()` was used to separate rows and columns. I have added logic to maintain line breaks inside double quotes in the CSV content. Test code has also been added.