### PR TITLE
Fix maximum update depth exceeded

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -57,15 +57,20 @@ export const Cell: React.FC<Types.CellComponentProps> = ({
     [setCellDimensions, select, dragging, point]
   );
 
+  const modeRef = React.useRef<Types.Mode>();
+  React.useEffect(() => {
+    modeRef.current = mode;
+  }, [mode]);
+
   React.useEffect(() => {
     const root = rootRef.current;
     if (selected && root) {
       setCellDimensions(point, getOffsetRect(root));
     }
-    if (root && active && mode === "view") {
+    if (root && active && modeRef.current === "view") {
       root.focus();
     }
-  }, [setCellDimensions, selected, active, mode, point, data]);
+  }, [setCellDimensions, selected, active, point, data]);
 
   if (data && data.DataViewer) {
     // @ts-ignore

--- a/src/Spreadsheet.tsx
+++ b/src/Spreadsheet.tsx
@@ -16,6 +16,7 @@ import {
   getCSV,
   shouldHandleClipboardEvent,
   isFocusedWithin,
+  deepArrayComparison,
 } from "./util";
 
 import DefaultTable from "./Table";
@@ -235,13 +236,12 @@ const Spreadsheet = <CellType extends Types.CellBase>(
   // Listen to data changes
   const prevDataRef = React.useRef<Matrix.Matrix<CellType>>(state.model.data);
   React.useEffect(() => {
-    if (state.model.data !== prevDataRef.current) {
+    if (!deepArrayComparison(state.model.data, prevDataRef.current)) {
       // Call on change only if the data change internal
-      if (state.model.data !== props.data) {
+      if (!deepArrayComparison(state.model.data, props.data)) {
         onChange(state.model.data);
       }
     }
-
     prevDataRef.current = state.model.data;
   }, [state.model.data, onChange, props.data]);
 
@@ -252,7 +252,6 @@ const Spreadsheet = <CellType extends Types.CellBase>(
     if (state?.model?.evaluatedData !== prevEvaluatedDataRef?.current) {
       onEvaluatedDataChange(state?.model?.evaluatedData);
     }
-
     prevEvaluatedDataRef.current = state.model.evaluatedData;
   }, [state?.model?.evaluatedData, onEvaluatedDataChange]);
 

--- a/src/Spreadsheet.tsx
+++ b/src/Spreadsheet.tsx
@@ -171,7 +171,7 @@ const Spreadsheet = <CellType extends Types.CellBase>(
 
   const size = React.useMemo(() => {
     return calculateSpreadsheetSize(state.model.data, rowLabels, columnLabels);
-  }, [state.model.data, rowLabels, columnLabels]);
+  }, [state.lastUpdateDate, rowLabels, columnLabels]);
 
   const mode = state.mode;
 
@@ -241,6 +241,7 @@ const Spreadsheet = <CellType extends Types.CellBase>(
   }, [state.model.data]);
 
   React.useEffect(() => {
+    if (state.lastUpdateDate === null) return;
     onChange(currentModelDataRef.current);
   }, [state.lastUpdateDate, onChange]);
 

--- a/src/Spreadsheet.tsx
+++ b/src/Spreadsheet.tsx
@@ -171,7 +171,7 @@ const Spreadsheet = <CellType extends Types.CellBase>(
 
   const size = React.useMemo(() => {
     return calculateSpreadsheetSize(state.model.data, rowLabels, columnLabels);
-  }, [state.lastUpdateDate, rowLabels, columnLabels]);
+  }, [state.model.data, rowLabels, columnLabels]);
 
   const mode = state.mode;
 

--- a/src/Spreadsheet.tsx
+++ b/src/Spreadsheet.tsx
@@ -16,7 +16,6 @@ import {
   getCSV,
   shouldHandleClipboardEvent,
   isFocusedWithin,
-  deepArrayComparison,
 } from "./util";
 
 import DefaultTable from "./Table";
@@ -234,16 +233,16 @@ const Spreadsheet = <CellType extends Types.CellBase>(
   }, [onActivate, onBlur, state.active]);
 
   // Listen to data changes
-  const prevDataRef = React.useRef<Matrix.Matrix<CellType>>(state.model.data);
+  const currentModelDataRef = React.useRef<Matrix.Matrix<CellType>>(
+    state.model.data
+  );
   React.useEffect(() => {
-    if (!deepArrayComparison(state.model.data, prevDataRef.current)) {
-      // Call on change only if the data change internal
-      if (!deepArrayComparison(state.model.data, props.data)) {
-        onChange(state.model.data);
-      }
-    }
-    prevDataRef.current = state.model.data;
-  }, [state.model.data, onChange, props.data]);
+    currentModelDataRef.current = state.model.data;
+  }, [state.model.data]);
+
+  React.useEffect(() => {
+    onChange(currentModelDataRef.current);
+  }, [state.lastUpdateDate, onChange]);
 
   const prevEvaluatedDataRef = React.useRef<Matrix.Matrix<CellType>>(
     state.model.evaluatedData

--- a/src/reducer.test.ts
+++ b/src/reducer.test.ts
@@ -223,7 +223,13 @@ describe("reducer", () => {
     ],
   ];
   test.each(cases)("%s", (name, state, action, expected) => {
-    expect(reducer(state, action)).toEqual(expected);
+    if (name === "setCellData") {
+      // Addressing this case separately since the test may fail due to slight time-related
+      // differences between the generation of the expected and obtained results.
+      const result = reducer(state, action);
+      result.lastUpdateDate = null;
+      expect(result).toEqual(expected);
+    } else expect(reducer(state, action)).toEqual(expected);
   });
 });
 

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -20,6 +20,7 @@ export const INITIAL_STATE: Types.StoreState = {
   rowDimensions: {},
   columnDimensions: {},
   lastChanged: null,
+  lastUpdateDate: null,
   hasPasted: false,
   cut: false,
   dragging: false,
@@ -132,6 +133,7 @@ export default function reducer(
         ...state,
         model: updateCellValue(state.model, active, cellData),
         lastChanged: active,
+        lastUpdateDate: new Date(),
       };
     }
     case Actions.SET_CELL_DIMENSIONS: {
@@ -206,6 +208,7 @@ export default function reducer(
           hasPasted: true,
           mode: "view",
           lastCommit: commit,
+          lastUpdateDate: new Date(),
         };
       }
 
@@ -276,6 +279,7 @@ export default function reducer(
         hasPasted: true,
         mode: "view",
         lastCommit: acc.commit,
+        lastUpdateDate: new Date(),
       };
     }
 
@@ -385,6 +389,7 @@ function clear(state: Types.StoreState): Types.StoreState {
     ...state,
     model: new Model(createFormulaParser, newData),
     ...commit(changes),
+    lastUpdateDate: new Date(),
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export type StoreState<Cell extends CellBase = CellBase> = {
   >;
   dragging: boolean;
   lastChanged: Point | null;
+  lastUpdateDate: Date | null;
   lastCommit: null | CellChange<Cell>[];
 };
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -54,6 +54,7 @@ const EXAMPLE_STATE: Types.StoreState = {
     },
   },
   lastChanged: null,
+  lastUpdateDate: null,
   hasPasted: false,
   cut: false,
   dragging: false,

--- a/src/util.ts
+++ b/src/util.ts
@@ -34,6 +34,17 @@ export function range(end: number, start = 0, step = 1): number[] {
   return array;
 }
 
+/** Perform deep comparison of two (nested) arrays. */
+export function deepArrayComparison(arr1: any[], arr2: any[]): boolean {
+  if (arr1.length !== arr2.length) return false;
+  return arr1.every((element, index) => {
+    if (Array.isArray(element) && Array.isArray(arr2[index])) {
+      return deepArrayComparison(element, arr2[index]);
+    }
+    return element === arr2[index];
+  });
+}
+
 /** Return whether given point is active */
 export function isActive(
   active: Types.StoreState["active"],

--- a/src/util.ts
+++ b/src/util.ts
@@ -34,17 +34,6 @@ export function range(end: number, start = 0, step = 1): number[] {
   return array;
 }
 
-/** Perform deep comparison of two (nested) arrays. */
-export function deepArrayComparison(arr1: any[], arr2: any[]): boolean {
-  if (arr1.length !== arr2.length) return false;
-  return arr1.every((element, index) => {
-    if (Array.isArray(element) && Array.isArray(arr2[index])) {
-      return deepArrayComparison(element, arr2[index]);
-    }
-    return element === arr2[index];
-  });
-}
-
 /** Return whether given point is active */
 export function isActive(
   active: Types.StoreState["active"],


### PR DESCRIPTION
Hi, 
I encountered an issue in my project similar to that described in this open issue [link](https://github.com/iddan/react-spreadsheet/issues/279).

When using the code snippet below:

```tsx
<Spreadsheet
  data={data}
  onChange={(newData: any) => {
    console.log(newData);
    setData(newData);
  }}
/>
```

Every time I made a change in a cell, I noticed that console.log was being called infinitely.

Upon investigation, I found that the issue lies within the Spreadsheet.tsx file, specifically in the following useEffect:

```ts
React.useEffect(() => {
  if (state.model.data !== prevDataRef.current) {
    // Call onChange only if the data changes internally
    if (state.model.data !== props.data) {
      onChange(state.model.data);
    }
  }
  prevDataRef.current = state.model.data;
}, [state.model.data, onChange, props.data]);
```

The problem arises from the comparisons made inside the useEffect's callback function and within the dependency array. Since we are comparing two non-primitive variables, these inequality comparisons always return true. Consequently, when the value of a cell changes, state.model.data varies, triggering the useEffect. However, the two if conditions always evaluate to true, leading to the invocation of onChange. As onChange sets new props, the useEffect is triggered again, resulting in an infinite loop.

To address this issue, I created a new function in the util.ts file that enables deep comparison of arrays. By using this function within the useEffect body, I ensure that the infinite loop is halted, and onChange is called only once.