### PR TITLE
Expose activate method

### DIFF
--- a/src/Spreadsheet.tsx
+++ b/src/Spreadsheet.tsx
@@ -129,7 +129,7 @@ export type Props<CellType extends Types.CellBase> = {
 
 export type SpreadsheetRef = {
   /**
-   * provide point as props to which one want to activate
+   * Pass the desired point as a prop to specify which one should be activated.
    */
   activate: (point: Point.Point) => void;
 };

--- a/src/Spreadsheet.tsx
+++ b/src/Spreadsheet.tsx
@@ -124,10 +124,23 @@ export type Props<CellType extends Types.CellBase> = {
 };
 
 /**
+ * The Spreadsheet Ref Type
+ */
+
+export type SpreadsheetRef = {
+  /**
+   * provide point as props to which one want to activate
+   */
+  activate: (point: Point.Point) => void;
+};
+
+/**
  * The Spreadsheet component
  */
-const Spreadsheet = <CellType extends Types.CellBase>(
-  props: Props<CellType>
+
+const Spreadsheet = <SpreadsheetRef, CellType extends Types.CellBase>(
+  props: Props<CellType>,
+  ref: React.ForwardedRef<SpreadsheetRef>
 ): React.ReactElement => {
   const {
     className,
@@ -198,6 +211,23 @@ const Spreadsheet = <CellType extends Types.CellBase>(
   const setCreateFormulaParser = useAction(Actions.setCreateFormulaParser);
   const blur = useAction(Actions.blur);
   const setSelection = useAction(Actions.setSelection);
+  const activate = useAction(Actions.activate);
+
+  // Memoize methods to be exposed via ref
+  const methods = React.useMemo(
+    () => ({
+      activate: (point: Point.Point) => {
+        activate(point);
+      },
+    }),
+    []
+  );
+
+  // Expose methods to parent via ref
+  React.useImperativeHandle<SpreadsheetRef, SpreadsheetRef>(
+    ref,
+    () => methods as SpreadsheetRef
+  );
 
   // Track active
   const prevActiveRef = React.useRef<Point.Point | null>(state.active);
@@ -557,4 +587,4 @@ const Spreadsheet = <CellType extends Types.CellBase>(
   );
 };
 
-export default Spreadsheet;
+export default React.forwardRef(Spreadsheet);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-import Spreadsheet from "./Spreadsheet";
+import Spreadsheet, { SpreadsheetRef } from "./Spreadsheet";
 import DataEditor from "./DataEditor";
 import DataViewer from "./DataViewer";
 
 export default Spreadsheet;
-export { Spreadsheet, DataEditor, DataViewer };
+export { Spreadsheet, DataEditor, DataViewer, SpreadsheetRef };
 export type { Props } from "./Spreadsheet";
 export { createEmpty as createEmptyMatrix } from "./matrix";
 export type { Matrix } from "./matrix";

--- a/src/stories/Spreadsheet.stories.tsx
+++ b/src/stories/Spreadsheet.stories.tsx
@@ -10,6 +10,8 @@ import {
   EntireRowsSelection,
   EntireColumnsSelection,
   EmptySelection,
+  Point,
+  SpreadsheetRef,
 } from "..";
 import * as Matrix from "../matrix";
 import { AsyncCellDataEditor, AsyncCellDataViewer } from "./AsyncCellData";
@@ -17,7 +19,6 @@ import CustomCell from "./CustomCell";
 import { RangeEdit, RangeView } from "./RangeDataComponents";
 import { SelectEdit, SelectView } from "./SelectDataComponents";
 import { CustomCornerIndicator } from "./CustomCornerIndicator";
-
 type StringCell = CellBase<string | undefined>;
 type NumberCell = CellBase<number | undefined>;
 
@@ -302,6 +303,52 @@ export const ControlledSelection: StoryFn<Props<StringCell>> = (props) => {
         </button>
       </div>
       <Spreadsheet {...props} selected={selected} onSelect={handleSelect} />;
+    </div>
+  );
+};
+
+export const ControlledActivation: StoryFn<Props<StringCell>> = (props) => {
+  const spreadsheetRef = React.useRef<SpreadsheetRef>();
+
+  const [activationPoint, setActivationPoint] = React.useState<Point>({
+    row: 0,
+    column: 0,
+  });
+
+  const handleActivate = React.useCallback(() => {
+    spreadsheetRef.current?.activate(activationPoint);
+  }, [activationPoint]);
+
+  return (
+    <div>
+      <div>
+        <input
+          id="row"
+          title="row"
+          type="number"
+          value={activationPoint.row}
+          onChange={(e) =>
+            setActivationPoint(() => ({
+              ...activationPoint,
+              row: Number(e.target.value),
+            }))
+          }
+        />
+        <input
+          id="column"
+          title="row"
+          type="column"
+          value={activationPoint.column}
+          onChange={(e) =>
+            setActivationPoint(() => ({
+              ...activationPoint,
+              column: Number(e.target.value),
+            }))
+          }
+        />
+        <button onClick={handleActivate}>Activate</button>
+      </div>
+      <Spreadsheet ref={spreadsheetRef} {...props} />;
     </div>
   );
 };


### PR DESCRIPTION
Enhance Spreadsheet component with ref support and add related tests

- Introduced `SpreadsheetRef` type to expose an `activate` method for cell activation.
- Updated `Spreadsheet` component to support forwarding refs and added memoized methods.
- Enhanced tests to cover new ref methods, ensuring they are stable and handle invalid points gracefully.
- Added a new story for controlled activation demonstrating the use of the ref.

**This update improves the usability of the Spreadsheet component by allowing parent components to programmatically activate cells.**

### Test case result.

![image](https://github.com/user-attachments/assets/7345ca10-df6b-4b45-9814-a0e76a639cc9)

